### PR TITLE
Fix code scanning alert no. 1: CSRF protection weakened or disabled

### DIFF
--- a/app/app/controllers/graphql_controller.rb
+++ b/app/app/controllers/graphql_controller.rb
@@ -1,6 +1,6 @@
 class GraphqlController < ApplicationController
   
-  protect_from_forgery with: :null_session
+  protect_from_forgery with: :exception
 
   def execute
     result = GraphqlTutorialSchema.execute(query, variables: variables, context: context, operation_name: operation_name)


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_2/security/code-scanning/1](https://github.com/Brook-5686/Ruby_2/security/code-scanning/1)

To fix the CSRF vulnerability, we should re-enable the default CSRF protection mechanism by changing the `protect_from_forgery` method to raise an exception on invalid CSRF tokens. This can be achieved by using `protect_from_forgery with: :exception`. This change ensures that any request with an invalid or missing CSRF token will be blocked, preventing potential CSRF attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
